### PR TITLE
CR5: Add desktop kit type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-template",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/views/corewidgets/components/dashboard-index/dashboard-index.component.ts
+++ b/src/app/views/corewidgets/components/dashboard-index/dashboard-index.component.ts
@@ -71,6 +71,7 @@ export class DashboardIndexComponent {
 
   styles = {
     'LAPTOP': {title: 'Laptops', style: 'primary', progress: 0},
+    'DESKTOP': {title: 'Desktops', style: 'primary', progress: 0},
     'CHROMEBOOK': {title: 'Chromebooks', style: 'primary', progress: 0},
     'TABLET': {title: 'Tablets', style: 'info', progress: 0},
     'OTHER': {title: 'Other', style: 'danger', progress: 0},

--- a/src/app/views/corewidgets/components/donor-request/donor-request.component.ts
+++ b/src/app/views/corewidgets/components/donor-request/donor-request.component.ts
@@ -112,12 +112,12 @@ export class DonorRequestComponent {
       className: 'col-md-12',
       defaultValue: 'DROPOFF',
       templateOptions: {
-        label: 'Are you able to drop off your device to a location in Streatham or would you need it to be collected?',
+        label: 'Are you able to drop off your device to a location in Lambeth or would you need it to be collected?',
         placeholder: '',
         postCode: false,
         required: true,
         options: [
-          { label: 'I am able to drop off my device to a location in Streatham', value: 'DROPOFF' },
+          { label: 'I am able to drop off my device to a location in Lambeth', value: 'DROPOFF' },
           { label: 'I would need you to come and collect my device', value: 'PICKUP' },
           { label: 'I\'m not sure – it depends on the exact location', value: 'NOTSURE' }
         ]

--- a/src/app/views/corewidgets/components/donor-request/donor-request.component.ts
+++ b/src/app/views/corewidgets/components/donor-request/donor-request.component.ts
@@ -185,6 +185,7 @@ export class DonorRequestComponent {
                         {label: 'Chromebook', value: 'CHROMEBOOK' },
                         {label: 'Smart Phone', value: 'SMARTPHONE' },
                         {label: 'All In One (PC)', value: 'ALLINONE' },
+                        {label: 'Desktop', value: 'DESKTOP' },
                         {label: 'Other', value: 'OTHER' }
                       ],
                       required: true

--- a/src/app/views/corewidgets/components/kit-index/kit-index.component.ts
+++ b/src/app/views/corewidgets/components/kit-index/kit-index.component.ts
@@ -394,11 +394,11 @@ export class KitIndexComponent {
       className: 'col-md-12',
       defaultValue: 'DROPOFF',
       templateOptions: {
-        label: 'Are you able to drop off your device to a location in Streatham Hill or would you need it to be collected?',
+        label: 'Are you able to drop off your device to a location in Lambeth or would you need it to be collected?',
         placeholder: '',
         required: true,
         options: [
-          { label: 'I am able to drop off my device to a location in Streatham Hill', value: 'DROPOFF' },
+          { label: 'I am able to drop off my device to a location in Lambeth', value: 'DROPOFF' },
           { label: 'I would need you to come and collect my device', value: 'PICKUP' },
           { label: 'I\'m not sure – it depends on the exact location', value: 'NOTSURE' }
         ]

--- a/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
+++ b/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
@@ -482,11 +482,11 @@ export class KitInfoComponent {
       className: 'col-md-12',
       defaultValue: 'DROPOFF',
       templateOptions: {
-        label: 'Are you able to drop off your device to a location in Streatham Hill or would you need it to be collected?',
+        label: 'Are you able to drop off your device to a location in Lambeth or would you need it to be collected?',
         placeholder: '',
         required: true,
         options: [
-          { label: 'I am able to drop off my device to a location in Streatham Hill', value: 'DROPOFF' },
+          { label: 'I am able to drop off my device to a location in Lambeth', value: 'DROPOFF' },
           { label: 'I would need you to come and collect my device', value: 'PICKUP' },
           { label: 'I\'m not sure – it depends on the exact location', value: 'NOTSURE' }
         ]

--- a/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
+++ b/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
@@ -543,6 +543,7 @@ export class KitInfoComponent {
                   {label: 'Tablet', value: 'TABLET' },
                   {label: 'Smart Phone', value: 'SMARTPHONE' },
                   {label: 'All In One (PC)', value: 'ALLINONE' },
+                  {label: 'Desktop', value: 'DESKTOP' },
                   {label: 'Other', value: 'OTHER' }
                 ],
                 required: true

--- a/src/app/views/corewidgets/components/map-view/map-view.component.ts
+++ b/src/app/views/corewidgets/components/map-view/map-view.component.ts
@@ -183,7 +183,8 @@ export class MapViewComponent {
               {value: 'OTHER_TABLETS', label: 'All Other Tablets ( Windows )' },
               {value: 'WINDOWS_LAPTOPS', label: 'Windows Laptops' },
               {value: 'WINDOWS_ALLINONES', label: 'Windows All In Ones' },
-              {value: 'LINUX_LAPTOPS', label: 'Capable of Installing Linux on Old Windows Laptops' },
+              {value: 'WINDOWS_DESKTOPS', label: 'Windows Desktops' },
+              {value: 'LINUX_LAPTOPS', label: 'Capable of Installing Linux on Old Windows Computers' },
               {value: 'APPLE_LAPTOPS', label: 'Apple Macbooks' },
               {value: 'APPLE_ALLINONES', label: 'Apple iMacs (All In One)' },
             ]

--- a/src/app/views/corewidgets/components/map-view/map-view.component.ts
+++ b/src/app/views/corewidgets/components/map-view/map-view.component.ts
@@ -308,6 +308,7 @@ export class MapViewComponent {
       const types = {
         'CHROMEBOOK': 'https://cdn.mapmarker.io/api/v1/font-awesome/v5/pin?icon=fa-laptop&size=50&hoffset=0&voffset=-1&background=30475E',
         'LAPTOP': 'https://cdn.mapmarker.io/api/v1/font-awesome/v5/pin?icon=fa-laptop&size=50&hoffset=0&voffset=-1&background=30475E',
+        'DESKTOP': 'https://cdn.mapmarker.io/api/v1/font-awesome/v5/pin?icon=fa-laptop&size=50&hoffset=0&voffset=-1&background=30475E',
         'TABLET': 'https://cdn.mapmarker.io/api/v1/font-awesome/v5/pin?icon=fa-tablet&size=50&hoffset=0&voffset=-1&background=D8345F',
         'SMARTPHONE': 'https://cdn.mapmarker.io/api/v1/font-awesome/v5/pin?icon=fa-mobile&size=50&hoffset=0&voffset=-1&background=DE7118',
         'ALLINONE': 'https://cdn.mapmarker.io/api/v1/font-awesome/v5/pin?icon=fa-tv&size=50&hoffset=0&voffset=-1&background=9C5517',

--- a/src/app/views/corewidgets/components/volunteer-index/volunteer-index.component.ts
+++ b/src/app/views/corewidgets/components/volunteer-index/volunteer-index.component.ts
@@ -325,7 +325,7 @@ export class VolunteersIndexComponent {
               type: 'radio',
               className: '',
               templateOptions: {
-                label: 'Would you like to be involved with the organisation of Streatham TechAid?',
+                label: 'Would you like to be involved with the organisation of Lambeth TechAid?',
                 options: [
                   {label: 'Yes', value: 'yes' },
                   {label: 'No', value: 'no' }

--- a/src/app/views/corewidgets/components/volunteer-index/volunteer-index.component.ts
+++ b/src/app/views/corewidgets/components/volunteer-index/volunteer-index.component.ts
@@ -189,7 +189,8 @@ export class VolunteersIndexComponent {
                   {value: 'OTHER_TABLETS', label: 'All Other Tablets ( Windows )' },
                   {value: 'WINDOWS_LAPTOPS', label: 'Windows Laptops' },
                   {value: 'WINDOWS_ALLINONES', label: 'Windows All In Ones' },
-                  {value: 'LINUX_LAPTOPS', label: 'Capable of Installing Linux on Old Windows Laptops' },
+                  {value: 'WINDOWS_DESKTOPS', label: 'Windows Desktops' },
+                  {value: 'LINUX_LAPTOPS', label: 'Capable of Installing Linux on Old Windows Computers' },
                   {value: 'APPLE_LAPTOPS', label: 'Apple Macbooks' },
                   {value: 'APPLE_ALLINONES', label: 'Apple iMacs (All In One)' },
                 ]
@@ -437,7 +438,8 @@ export class VolunteersIndexComponent {
                   {value: 'OTHER_TABLETS', label: 'All Other Tablets ( Windows )' },
                   {value: 'WINDOWS_LAPTOPS', label: 'Windows Laptops' },
                   {value: 'WINDOWS_ALLINONES', label: 'Windows All In Ones' },
-                  {value: 'LINUX_LAPTOPS', label: 'Capable of Installing Linux on Old Windows Laptops' },
+                  {value: 'WINDOWS_DESKTOPS', label: 'Windows Desktops' },
+                  {value: 'LINUX_LAPTOPS', label: 'Capable of Installing Linux on Old Windows Computers' },
                   {value: 'APPLE_LAPTOPS', label: 'Apple Macbooks' },
                   {value: 'APPLE_ALLINONES', label: 'Apple iMacs (All In One)' },
                 ],
@@ -563,6 +565,23 @@ export class VolunteersIndexComponent {
                   templateOptions: {
                     min: 0,
                     label: 'All In Ones',
+                    addonLeft: {
+                      class: 'fas fa-desktop'
+                    },
+                    type: 'number',
+                    placeholder: '',
+                    required: true
+                  }
+                },
+                {
+                  key: 'attributes.capacity.desktops',
+                  type: 'input',
+                  className: 'col-6',
+                  hideExpression: 'model.attributes.accepts.toString().indexOf(\'DESKTOP\') < 0',
+                  defaultValue: 0,
+                  templateOptions: {
+                    min: 0,
+                    label: 'Desktops',
                     addonLeft: {
                       class: 'fas fa-desktop'
                     },

--- a/src/app/views/corewidgets/components/volunteer-info/volunteer-info.component.ts
+++ b/src/app/views/corewidgets/components/volunteer-info/volunteer-info.component.ts
@@ -230,7 +230,7 @@ export class VolunteerInfoComponent {
               defaultValue: 'no',
               templateOptions: {
                 label:
-                  'Would you like to be involved with the organisation of Streatham TechAid?',
+                  'Would you like to be involved with the organisation of Lambeth TechAid?',
                 options: [
                   { label: 'Yes', value: 'yes' },
                   { label: 'No', value: 'no' }

--- a/src/app/views/corewidgets/components/volunteer-info/volunteer-info.component.ts
+++ b/src/app/views/corewidgets/components/volunteer-info/volunteer-info.component.ts
@@ -35,6 +35,7 @@ const QUERY_ENTITY = gql`
           tablets
           laptops
           allInOnes
+          desktops
         }
       }
     }
@@ -65,6 +66,7 @@ const UPDATE_ENTITY = gql`
           tablets
           laptops
           allInOnes
+          desktops
         }
       }
     }
@@ -352,9 +354,10 @@ export class VolunteerInfoComponent {
                   },
                   { value: 'WINDOWS_LAPTOPS', label: 'Windows Laptops' },
                   { value: 'WINDOWS_ALLINONES', label: 'Windows All In Ones' },
+                  { value: 'WINDOWS_DESKTOPS', label: 'Windows Desktops' },
                   {
                     value: 'LINUX_LAPTOPS',
-                    label: 'Capable of Installing Linux on Old Windows Laptops',
+                    label: 'Capable of Installing Linux on Old Windows Computers',
                   },
                   { value: 'APPLE_LAPTOPS', label: 'Apple Macbooks' },
                   {
@@ -513,6 +516,31 @@ export class VolunteerInfoComponent {
                   templateOptions: {
                     min: 0,
                     label: 'All In Ones',
+                    addonLeft: {
+                      class: 'fas fa-desktop',
+                    },
+                    type: 'number',
+                    placeholder: '',
+                    required: true,
+                  },
+                  validation: {
+                    show: false,
+                  },
+                  expressionProperties: {
+                    'validation.show': 'model.showErrorState',
+                    'templateOptions.disabled': 'formState.disabled',
+                  },
+                },
+                {
+                  key: 'attributes.capacity.desktops',
+                  type: 'input',
+                  className: 'col-6',
+                  hideExpression:
+                    '!model.attributes.accepts || model.attributes.accepts.toString().indexOf(\'DESKTOP\') < 0',
+                  defaultValue: 0,
+                  templateOptions: {
+                    min: 0,
+                    label: 'Desktops',
                     addonLeft: {
                       class: 'fas fa-desktop',
                     },

--- a/src/app/views/corewidgets/components/volunteer/volunteer.ts
+++ b/src/app/views/corewidgets/components/volunteer/volunteer.ts
@@ -155,7 +155,7 @@ export class VolunteerComponent {
               type: 'radio',
               className: '',
               templateOptions: {
-                label: 'Would you like to be involved with the organisation of Streatham TechAid?',
+                label: 'Would you like to be involved with the organisation of Lambeth TechAid?',
                 options: [
                   {label: 'Yes', value: 'yes' },
                   {label: 'No', value: 'no' },

--- a/src/app/views/corewidgets/components/volunteer/volunteer.ts
+++ b/src/app/views/corewidgets/components/volunteer/volunteer.ts
@@ -268,7 +268,8 @@ export class VolunteerComponent {
                   {value: 'OTHER_TABLETS', label: 'All Other Tablets ( Windows )' },
                   {value: 'WINDOWS_LAPTOPS', label: 'Windows Laptops' },
                   {value: 'WINDOWS_ALLINONES', label: 'Windows All In Ones' },
-                  {value: 'LINUX_LAPTOPS', label: 'Capable of Installing Linux on Old Windows Laptops' },
+                  {value: 'WINDOWS_DESKTOPS', label: 'Windows Desktops' },
+                  {value: 'LINUX_LAPTOPS', label: 'Capable of Installing Linux on Old Windows Computers' },
                   {value: 'APPLE_LAPTOPS', label: 'Apple Macbooks' },
                   {value: 'APPLE_ALLINONES', label: 'Apple iMacs (All In One)' },
                 ],
@@ -394,6 +395,23 @@ export class VolunteerComponent {
                   templateOptions: {
                     min: 0,
                     label: 'All In Ones',
+                    addonLeft: {
+                      class: 'fas fa-desktop'
+                    },
+                    type: 'number',
+                    placeholder: '',
+                    required: true
+                  }
+                },
+                {
+                  key: 'attributes.capacity.desktops',
+                  type: 'input',
+                  className: 'col-6',
+                  hideExpression: 'model.attributes.accepts.toString().indexOf(\'DESKTOP\') < 0',
+                  defaultValue: 0,
+                  templateOptions: {
+                    min: 0,
+                    label: 'Desktops',
                     addonLeft: {
                       class: 'fas fa-desktop'
                     },

--- a/src/environments/version.ts
+++ b/src/environments/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = {version: '1.0.0', build: '20.07.29-2244', date: '2020-07-29T21:44:29.116Z'};
+export const APP_VERSION = {version: '1.0.1', build: '20.12.12-1248', date: '2020-12-12T12:48:44.922Z'};


### PR DESCRIPTION
Add desktop option to donate device page, create volunteer page, as well as the corresponding views. Also took the opportunity to replace all mentions of "Streatham" I could find with "Lambeth".